### PR TITLE
removed spaces from npc and shop names.

### DIFF
--- a/index.html
+++ b/index.html
@@ -969,7 +969,7 @@
                         }
                     ]
                 },
-                "Seaside Lodge": {
+                "SeasideLodge": {
                     "schedule_blocks": [
                         {
                             "weekDays": "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday",
@@ -985,7 +985,7 @@
                         }
                     ]
                 },
-                "Won Seed Corner": {
+                "WonSeedCorner": {
                     "schedule_blocks": [
                         {
                             "weekDays": "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday",
@@ -1001,7 +1001,7 @@
                         }
                     ]
                 },
-                "Harvest Sprites": {
+                "HarvestSprites": {
                     "schedule_blocks": [
                         {
                             "weekDays": "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday",


### PR DESCRIPTION
Quick fix for errors with retaining schedules when hitting next and previous buttons. Fixes delete button for shops and npcs with spaces in the name. It would be nice if the names could be fully legible with spaces. I can create another issue for figuring out how to fix that, but this should at least make it functional.

Also fixed getSchedule function to correctly handle specific day requirements. I didn't see any use of specific days here, but it is something i fixed for the hm64 one.

resolves #4 
resolves #6 